### PR TITLE
修复 win10 闪退问题

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ func main() {
 		args = append(args, "--class=Lorca")
 	}
 	if runtime.GOOS == "windows" {
-		args = append(args, "-ldflags '-H windowsgui'")
+		args = append(args, "-ldflags '-H windowsgui'", "--remote-allow-origins=*")
 	}
 
 	// New Lorca UI


### PR DESCRIPTION
Hi,

Websocket connection failure causes software to exit. As explained in #38 , websocket.Dial() function got bad status.
Fix this problem by adding a new option when connecting.

Fix #38 