### PR TITLE
fix: prevent path traversal in markdown file handler

### DIFF
--- a/apps/docs/main.go
+++ b/apps/docs/main.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -68,7 +69,15 @@ func md(c *gin.Context) {
 	name = strings.ReplaceAll(name, "-", "/")
 	mdpath := strings.Replace(name, ".html", ".md", -1)
 	engine.Printf("name =%s; ext=%s; mdfile =%s", name, ext, "md/"+mdpath)
-	data, err := os.ReadFile("docs/" + mdpath)
+
+	// Prevent path traversal: ensure the resolved path stays under docs/
+	fullPath := filepath.Join("docs", filepath.Clean(mdpath))
+	if !strings.HasPrefix(fullPath, "docs") {
+		c.String(http.StatusBadRequest, "invalid path")
+		return
+	}
+
+	data, err := os.ReadFile(fullPath)
 	if err != nil {
 		engine.Printf("%s", err)
 	}


### PR DESCRIPTION
## Summary

Prevent path traversal in the markdown file handler that converts hyphens to directory separators.

## Problem

The `md` handler converts hyphens in the URL parameter to slashes, then reads the file without path validation:

```go
name := c.Param("name")                        // user input
name = strings.ReplaceAll(name, "-", "/")       // hyphens become slashes
mdpath := strings.Replace(name, ".html", ".md", -1)
data, err := os.ReadFile("docs/" + mdpath)      // path traversal!
```

An attacker can read arbitrary files using `..` sequences encoded as hyphens:
- Request: `GET /docs/..-..-..-etc-passwd`
- After hyphen→slash: `../../etc/passwd`
- Reads: `docs/../../etc/passwd` → `/etc/passwd`

## Fix

- Use `filepath.Clean` to normalize the path and resolve `..` components
- Validate the resolved path stays under the `docs/` directory
- Use `filepath.Join` for safe path construction

## Impact

- **Type**: Path Traversal / Arbitrary File Read (CWE-22)
- **Risk**: Read any file on the server
- **OWASP**: A01:2021 — Broken Access Control